### PR TITLE
Cập nhật file path

### DIFF
--- a/modules/shops/admin/download.php
+++ b/modules/shops/admin/download.php
@@ -92,8 +92,8 @@ if( $nv_Request->isset_request( 'submit', 'post' ) )
 	$data['filesize'] = 0;
 	$data['extension'] = '';
 
-	$data['path'] = str_replace( NV_UPLOADS_DIR . '/' . $module_upload . '/', '', $data['path'] );
-	$real_file = NV_ROOTDIR . '/' . NV_UPLOADS_DIR . '/' . $module_upload . $data['path'];
+	$real_path = substr( $data['path'], strlen( NV_BASE_SITEURL ) );
+	$real_file = NV_ROOTDIR . '/' .  $real_path;
 
 	if( empty( $data['title'] ) )
 	{


### PR DESCRIPTION
Điều chỉnh fix lỗi " Sai đường dẫn " khi thêm tài liệu mới trong Admin.

Sửa lại cấu trúc file khi lưu.
Do cấu trúc đường dẫn bị sai, việc check filesize và tự tồn tại của file dựa trên URL bị sai.
URL sai : nukeviet/files/ten-file.pdf
URL đúng : uploads/shops/files/ten-file.pdf

Cơ bản, sau khi điều chỉnh thì lỗi trên không còn xuất hiện, đã nhận đúng path của file cũng như dung lượng.

Mới tập Pull/Push, nếu sai xin mọi người chỉ bảo.